### PR TITLE
[REFACTOR] 상세 페이지 헤더 변경

### DIFF
--- a/src/components/footer.css
+++ b/src/components/footer.css
@@ -32,11 +32,20 @@
   flex-wrap: wrap;
 }
 
-.footerDailyFundingLinkSection p, em {
+.footerDailyFundingLinkSection p {
   display: block;
   color: #666666;
   font-weight: 500;
   font-size: 18px;
+  letter-spacing: -0.36px;
+  margin: 0 5px 0 0;
+}
+.footerDailyFundingLinkSection em {
+  display: block;
+  color: #666666;
+  font-weight: 700;
+  font-size: 18px;
+  font-style: normal;
   letter-spacing: -0.36px;
   margin: 0 5px 0 0;
 }

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -14,6 +14,11 @@
   height: 38px;
 }
 
+.headerBackButton {
+  width: 20px;
+  height: 37px;
+}
+
 .headerDailyFundingLink {
   display: flex;
   align-items: center;
@@ -30,6 +35,11 @@
 .headerLinkSymbol {
   width: 29px;
   height: 29px;
+}
+
+.headerCancelButton {
+  width: 37px;
+  height: 37px;
 }
 
 @media (max-width: 1200px) {
@@ -88,6 +98,11 @@
     gap: 6px;
   }
 
+  .headerBackButton {
+    width: 15px;
+    height: 29px;
+  }
+
   .headerDailyFundingLink span {
     font-size: 12px;
   }
@@ -95,5 +110,16 @@
   .headerLinkSymbol {
     width: 16px;
     height: 16px;
+  }
+
+  .headerCancelButton {
+    width: 29px;
+    height: 29px;
+  }
+}
+
+@media (max-width: 414px) {
+  .headerObject {
+    padding: 27px 26px;
   }
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,29 +1,57 @@
 /* eslint-disable @next/next/no-img-element */
+"use client";
+
+import { usePathname } from "next/navigation";
 import "./header.css";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function Header() {
+  const pathName = usePathname();
+  const isPostPage = pathName.startsWith("/post/");
+  const router = useRouter();
+
   return (
     <div className="header">
       <header className="headerObject">
-        <img
-          className="headerDailyInsightLogo"
-          src="/header/daily-insight-logo.png"
-          alt=""
-        />
-        <a
-          href="https://new.daily-funding.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <div className="headerDailyFundingLink">
-            <span>데일리펀딩 바로가기</span>
+        {isPostPage ? (
+          <img
+            className="headerBackButton"
+            src="/header/header-left-arrow.png"
+            alt="뒤로 가기"
+            onClick={() => router.back()}
+          />
+        ) : (
+          <img
+            className="headerDailyInsightLogo"
+            src="/header/daily-insight-logo.png"
+            alt=""
+          />
+        )}
+        {isPostPage ? (
+          <Link href="/">
             <img
-              className="headerLinkSymbol"
-              src="/header/dailyfunding-link.png"
-              alt=""
+              className="headerCancelButton"
+              src="/header/header-cancel.png"
+              alt="홈으로 가기"
             />
-          </div>
-        </a>
+          </Link>
+        ) : (
+          <a
+            href="https://new.daily-funding.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <div className="headerDailyFundingLink">
+              <span>데일리펀딩 바로가기</span>
+              <img
+                className="headerLinkSymbol"
+                src="/header/dailyfunding-link.png"
+                alt=""
+              />
+            </div>
+          </a>
+        )}
       </header>
     </div>
   );


### PR DESCRIPTION
### 설명

상세 페이지에서 헤더의 레이아웃이 다르게 적용되는 부분을 적용했습니다.

### 관련 이슈

Closes #10 

### 작업 내용

- [ ] 상세 페이지 접속 시 헤더 좌/우측 아이템 변경
- [ ] 상세 페이지 헤더 좌/우측 아이템 라우팅 기능 추가

### 스크린샷 (Optional)

<img width="789" height="87" alt="스크린샷 2026-03-12 오후 5 16 34" src="https://github.com/user-attachments/assets/07b545e8-d53f-4fc1-9dfb-49ed83b295d0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 푸터 타이포그래피 간격값 조정
  * 헤더 버튼 크기 설정 및 반응형 디자인 개선

* **개선**
  * 헤더가 현재 페이지에 따라 동적으로 표시됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->