### PR TITLE
[REFACTOR] 카테고리섹션 이동 기능 구현

### DIFF
--- a/src/app/(home)/components/categoryButton.tsx
+++ b/src/app/(home)/components/categoryButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import "./categoryButton.css";
 import Link from "next/link";
 import { Category } from "@/src/types/post";
@@ -13,7 +13,8 @@ const ALL_CATEGORY: Category = {
 
 export default function CategoryButton() {
   const [categories, setCategories] = useState<Category[]>([]);
-  const sectionRef = useRef<HTMLDivElement | null>(null);
+  const searchParams = useSearchParams();
+  const currentCategoryId = Number(searchParams.get("category_id")) || 0;
 
   useEffect(() => {
     async function fetchCategories() {
@@ -27,10 +28,7 @@ export default function CategoryButton() {
         const fetchedCategories: Category[] = Array.isArray(data.categories)
           ? data.categories
           : [];
-
-        const categoriesWithAll = [ALL_CATEGORY, ...fetchedCategories];
-
-        setCategories(categoriesWithAll);
+        setCategories([ALL_CATEGORY, ...fetchedCategories]);
       } catch (error) {
         setCategories([ALL_CATEGORY]);
         console.error("Failed to fetch categories:", error);
@@ -39,23 +37,27 @@ export default function CategoryButton() {
 
     fetchCategories();
   }, []);
-  const searchParams = useSearchParams();
-  const currentCategoryId = Number(searchParams.get("category_id")) || 0;
 
   useEffect(() => {
-    const el = sectionRef.current;
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (searchParams.get("s") === "1") {
+      setTimeout(() => {
+        document.getElementById("post-section")?.scrollIntoView({ behavior: "smooth" });
+      }, 100);
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("s");
+      const newUrl = params.toString() ? `/?${params.toString()}` : "/";
+      window.history.replaceState(null, "", newUrl);
     }
-  }, [currentCategoryId]);
+  }, [searchParams]);
 
   return (
-    <div ref={sectionRef} className="categorySection">
+    <div className="categorySection">
       {categories.map((category) => {
         const href =
           category.category_id === 0
             ? "/"
-            : `/?category_id=${category.category_id}`;
+            : `/?category_id=${category.category_id}&s=1`;
 
         return (
           <Link

--- a/src/app/(home)/components/topCarousel.tsx
+++ b/src/app/(home)/components/topCarousel.tsx
@@ -6,10 +6,12 @@ import "./topCarousel.css";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { TopPost } from "@/src/types/post";
+import Link from "next/link";
 
 const mockPosts: TopPost[] = [
   {
     post_id: 1,
+    category_id: 1,
     title: "데일리펀딩 블로그에 오신 것을 환영합니다 환영 환영 환영묵",
     subtitle: "현재 게시물이 없어 임시 목업 데이터를 표시하고 있습니다.",
     preview_image: "/carousel/sample-image.jpg",
@@ -17,6 +19,7 @@ const mockPosts: TopPost[] = [
   },
   {
     post_id: 2,
+    category_id: 2,
     title: "데일리펀딩 블로그에 오신 것을 환영합니다 환영 환영 환영묵",
     subtitle: "현재 게시물이 없어 임시 목업 데이터를 표시하고 있습니다.",
     preview_image: "/carousel/sample-image.jpg",
@@ -68,7 +71,12 @@ export default function TopCarousel() {
           <div className="topCarouselSlide" key={post.post_id}>
             <img src={post.preview_image} alt="" />
             <div className="topCarouselTextSection">
-              <p className="category_badge">{post.category_name}</p>
+              <Link
+                href={`/?category_id=${post.category_id}&s=1`}
+                className="category_badge"
+              >
+                {post.category_name}
+              </Link>
               <button
                 type="button"
                 className="topCarouselPostLink"

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
   return (
     <div className="home">
       <TopCarousel />
-      <div className="postSection">
+      <div className="postSection" id="post-section">
         <Suspense fallback={null}>
           <CategoryButton />
         </Suspense>

--- a/src/app/post/[id]/components/topPost/index.tsx
+++ b/src/app/post/[id]/components/topPost/index.tsx
@@ -2,16 +2,22 @@
 "use client";
 
 import "./style.css";
+import Link from "next/link";
 import { TopPostProps } from "@/src/types/post";
 
-export default function TopPost({ post } : TopPostProps) {
+export default function TopPost({ post }: TopPostProps) {
   return (
     <div className="topPost">
       <div className="topPostTrack">
         <div className="topPostSlide">
           <img src={post.preview_image} alt="" />
           <div className="topPostTextSection">
-            <p className="category_badge">{post.category_name}</p>
+            <Link
+              href={`/?category_id=${post.category_id}&s=1`}
+              className="category_badge"
+            >
+              {post.category_name}
+            </Link>
             <h1 className="title">{post.title}</h1>
             <p className="subtitle">{post.subtitle}</p>
           </div>

--- a/src/app/post/[id]/components/topPost/style.css
+++ b/src/app/post/[id]/components/topPost/style.css
@@ -62,6 +62,8 @@
   border: 1px solid rgb(255, 255, 255);
   border-radius: 22px;
 
+  cursor: pointer;
+
   box-sizing: border-box;
 }
 

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,5 +1,6 @@
 export interface TopPost {
   post_id: number;
+  category_id: number;
   category_name: string;
   title: string;
   subtitle: string;


### PR DESCRIPTION
### 설명

- 홈페이지 상단 고정 게시물, 카테고리 버튼 클릭 시 카테고리 위치로 이동
- 상세페이지 상단 포스트 카테고리 버튼 클릭 시 홈페이지 카테고리 위치로 이동

### 관련 이슈

Closes #33 

### 작업 내용

- [x] 위치 이동용 useEffect 추가
- [x] topCarousel, topPost에 Link 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카테고리 배지를 클릭하여 해당 카테고리로 필터링된 페이지로 이동 가능
  * 특정 매개변수 조건에서 자동 스크롤 기능 추가

* **스타일**
  * 카테고리 배지 호버 시 마우스 커서를 포인터로 변경하여 클릭 가능함을 시각화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->