### PR TITLE
[BUG] 게시물 리스트에서 이미지와 info_div 사이의 간격이 이상하게 벌어진 버그 수정

### DIFF
--- a/src/app/(main)/(home)/components/post/postList.css
+++ b/src/app/(main)/(home)/components/post/postList.css
@@ -9,19 +9,20 @@
   width: 555px;
   height: 312px;
   margin-right: 42px;
-  overflow: hidden;  /* 여기서 클리핑 */
-  flex-shrink: 0;
+  overflow: hidden;
 }
 
 .article_item img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform 0.3s ease, filter 0.3s ease;
+  object-position: center;
+  transition:
+    transform 0.3s ease,
+    filter 0.3s ease;
   cursor: pointer;
   background-color: darkgray;
   filter: brightness(0.8);
-  /* width, height, margin-right 제거 */
 }
 
 .article_item img:hover {
@@ -159,6 +160,13 @@
     flex-direction: column;
     flex-wrap: wrap;
     transition: none;
+  }
+
+  .post_image_wrapper {
+    width: 100%;
+    height: 204px;
+    margin-right: 0;
+    margin-bottom: 20px;
   }
 
   .article_item img {


### PR DESCRIPTION
### 설명

게시물 리스트에서 이미지와 info_div 사이의 간격이 이상하게 벌어진 버그 수정
=> flex-shrink 때문인 것으로 판단
+ mobile에서도 post_image_wrapper 추가해 layout 깨지지 않도록 조정

### 관련 이슈

Closes #49 

### 작업 내용

- [ ] 모바일 대응 추가
- [ ] 간격 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 게시물 이미지 중앙 정렬 개선
  * 모바일 기기에서 이미지 레이아웃 및 간격 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->